### PR TITLE
Don't ignore retroachievements menu for vertical offset calculation when resizing main window

### DIFF
--- a/src/drivers/win/window.cpp
+++ b/src/drivers/win/window.cpp
@@ -1608,12 +1608,12 @@ LRESULT FAR PASCAL AppWndProc(HWND hWnd,UINT msg,WPARAM wParam,LPARAM lParam)
 			wrect->bottom = wrect->top + srect.bottom;
 		
 			GetMenuItemRect(hWnd, fceumenu, 0, &file_rect);
-#ifdef RETROACHIEVEMENTS
-			GetMenuItemRect(hWnd, fceumenu, 6, &retroachievements_rect);
-			menuYoffset = retroachievements_rect.top - file_rect.top;
-#else
 			GetMenuItemRect(hWnd, fceumenu, 5, &help_rect);
 			menuYoffset = help_rect.top-file_rect.top;
+
+#ifdef RETROACHIEVEMENTS
+			if(GetMenuItemRect(hWnd, fceumenu, 6, &retroachievements_rect))
+				menuYoffset = retroachievements_rect.top-file_rect.top;
 #endif
 		}
 		//sizchange=1;

--- a/src/drivers/win/window.cpp
+++ b/src/drivers/win/window.cpp
@@ -1427,6 +1427,9 @@ LRESULT FAR PASCAL AppWndProc(HWND hWnd,UINT msg,WPARAM wParam,LPARAM lParam)
 	POINT pt;
 	RECT file_rect;
 	RECT help_rect;
+#ifdef RETROACHIEVEMENTS
+	RECT retroachievements_rect;
+#endif
 	int x = 0;
 	
 	char TempArray[2048];
@@ -1605,8 +1608,13 @@ LRESULT FAR PASCAL AppWndProc(HWND hWnd,UINT msg,WPARAM wParam,LPARAM lParam)
 			wrect->bottom = wrect->top + srect.bottom;
 		
 			GetMenuItemRect(hWnd, fceumenu, 0, &file_rect);
+#ifdef RETROACHIEVEMENTS
+			GetMenuItemRect(hWnd, fceumenu, 6, &retroachievements_rect);
+			menuYoffset = retroachievements_rect.top - file_rect.top;
+#else
 			GetMenuItemRect(hWnd, fceumenu, 5, &help_rect);
 			menuYoffset = help_rect.top-file_rect.top;
+#endif
 		}
 		//sizchange=1;
 		//break;


### PR DESCRIPTION
When `Force integral scaling factors` is enabled, resizing the window to the smallest size pushes the `RetroAchievements` menu to a new line. This results in a compressed image, because the window is not tall enough, which shouldn't happen with this option enabled.