### PR TITLE
Rewinding on two keys in Rewinder.lua and disabling unnecessary output

### DIFF
--- a/output/luaScripts/Rewinder.lua
+++ b/output/luaScripts/Rewinder.lua
@@ -65,8 +65,8 @@ while (true) do
 		savestate.save(save);
 		saveArray[saveCount] = save;
 	end;
-	local HUDMATH = (math.ceil((100/saveMax)*rewindCount));--Making the rewind time a percentage.
-	local HUDTEXT = "REWIND POWER: ".. HUDMATH .."%"; 
+	--local HUDMATH = (math.ceil((100/saveMax)*rewindCount));--Making the rewind time a percentage.
+	--local HUDTEXT = "REWIND POWER: ".. HUDMATH .."%"; 
 	--gui.text(80,5,HUDTEXT);--Displaying the time onscreen.
 	FCEU.frameadvance();
 end;

--- a/output/luaScripts/Rewinder.lua
+++ b/output/luaScripts/Rewinder.lua
@@ -11,7 +11,8 @@
 
 --Which key you would like to function as the "rewind key"
 
-local rewindKey = 'select'
+local firstRewindKey = 'left'
+local secondRewindKey = 'start'
 
 
 --How much rewind power would you like? (The higher the number the further back in time you can go, but more computer memory is used up)
@@ -37,7 +38,7 @@ while (true) do
 		savePreventBuffer = 1;
 	end;
 	joyput	= joypad.read(1);
-	if joyput[rewindKey] then
+	if (joyput[firstRewindKey] and joyput[secondRewindKey]) then
 		savePreventBuffer = 5;
 		if rewindCount==0 then
 			--makes sure you can't go back too far could also include other things in here, left empty for now.	
@@ -51,7 +52,7 @@ while (true) do
 		end;
 	end;
 	if savePreventBuffer==1 then
-		gui.text(80,15,"");
+		--gui.text(80,15,"");
 		saveCount=saveCount+1;
 		if saveCount==saveMax then
 			saveCount = 1;
@@ -66,6 +67,6 @@ while (true) do
 	end;
 	local HUDMATH = (math.ceil((100/saveMax)*rewindCount));--Making the rewind time a percentage.
 	local HUDTEXT = "REWIND POWER: ".. HUDMATH .."%"; 
-	gui.text(80,5,HUDTEXT);--Displaying the time onscreen.
+	--gui.text(80,5,HUDTEXT);--Displaying the time onscreen.
 	FCEU.frameadvance();
 end;

--- a/src/drivers/win/args.cpp
+++ b/src/drivers/win/args.cpp
@@ -24,6 +24,8 @@
 #include "common.h"
 #include "../common/args.h"
 
+char* RomFile = 0;			//Loads a rom file (loads before any other commandline options
+int RunInFullscreen = 0;
 char* MovieToLoad = 0;		//Loads a movie file on startup
 char* StateToLoad = 0;		//Loads a savestate on startup (after a movie is loaded, if any)
 char* ConfigToLoad = 0;		//Loads a specific .cfg file (loads before any other commandline options
@@ -43,7 +45,9 @@ extern bool turbo;
 char *ParseArgies(int argc, char *argv[])
 {         
 	static ARGPSTRUCT FCEUArgs[]={
-		{"-pal",         &pal_setting_specified,  &PAL,                  0},
+		{"-rom",         0,                       &RomFile,               0x4001},
+		{"-fullscreen",  0,                       &RunInFullscreen,       0},
+		{"-pal",         &pal_setting_specified,  &PAL,                   0},
 	    {"-dendy",       &dendy_setting_specified,&dendy,                 0},
         {"-noicon",      0,                       &status_icon,           0},
         {"-gg",          0,                       &genie,                 0},

--- a/src/drivers/win/args.h
+++ b/src/drivers/win/args.h
@@ -1,3 +1,5 @@
+extern char* RomFile;		//Contains the filename of the rom file in the command line arguments
+extern int RunInFullscreen;
 extern char* MovieToLoad;	//Contains the filename of the savestate specified in the command line arguments
 extern char* StateToLoad;	//Contains the filename of the movie file specified in the command line arguments
 extern char* ConfigToLoad;	//Contains the filename of the config file specified in the command line arguments


### PR DESCRIPTION
Hi,
This adds rewind to two buttons instead of one, this allows the Select button to be used for its intended purpose.
I also removed the debug output, as it is unlikely to be needed by players.
Thanks.