### PR TITLE
Rewinding on two keys in Rewinder.lua and disabling unnecessary output

### DIFF
--- a/output/luaScripts/Rewinder.lua
+++ b/output/luaScripts/Rewinder.lua
@@ -11,7 +11,8 @@
 
 --Which key you would like to function as the "rewind key"
 
-local rewindKey = 'select'
+local firstRewindKey = 'left'
+local secondRewindKey = 'start'
 
 
 --How much rewind power would you like? (The higher the number the further back in time you can go, but more computer memory is used up)
@@ -37,7 +38,7 @@ while (true) do
 		savePreventBuffer = 1;
 	end;
 	joyput	= joypad.read(1);
-	if joyput[rewindKey] then
+	if (joyput[firstRewindKey] and joyput[secondRewindKey]) then
 		savePreventBuffer = 5;
 		if rewindCount==0 then
 			--makes sure you can't go back too far could also include other things in here, left empty for now.	
@@ -51,7 +52,7 @@ while (true) do
 		end;
 	end;
 	if savePreventBuffer==1 then
-		gui.text(80,15,"");
+		--gui.text(80,15,"");
 		saveCount=saveCount+1;
 		if saveCount==saveMax then
 			saveCount = 1;
@@ -64,8 +65,8 @@ while (true) do
 		savestate.save(save);
 		saveArray[saveCount] = save;
 	end;
-	local HUDMATH = (math.ceil((100/saveMax)*rewindCount));--Making the rewind time a percentage.
-	local HUDTEXT = "REWIND POWER: ".. HUDMATH .."%"; 
-	gui.text(80,5,HUDTEXT);--Displaying the time onscreen.
+	--local HUDMATH = (math.ceil((100/saveMax)*rewindCount));--Making the rewind time a percentage.
+	--local HUDTEXT = "REWIND POWER: ".. HUDMATH .."%"; 
+	--gui.text(80,5,HUDTEXT);--Displaying the time onscreen.
 	FCEU.frameadvance();
 end;


### PR DESCRIPTION
Hi,
This adds rewind to two buttons instead of one, this allows the Select button to be used for its intended purpose.
I also removed the debug output, as it is unlikely to be needed by players.
Thanks.