### PR TITLE
Fullscreen command line and run Lua script minimized

### DIFF
--- a/src/drivers/win/args.cpp
+++ b/src/drivers/win/args.cpp
@@ -24,6 +24,8 @@
 #include "common.h"
 #include "../common/args.h"
 
+char* RomFile = 0;			//Loads a rom file (loads before any other commandline options
+int RunInFullscreen = 0;
 char* MovieToLoad = 0;		//Loads a movie file on startup
 char* StateToLoad = 0;		//Loads a savestate on startup (after a movie is loaded, if any)
 char* ConfigToLoad = 0;		//Loads a specific .cfg file (loads before any other commandline options
@@ -43,7 +45,9 @@ extern bool turbo;
 char *ParseArgies(int argc, char *argv[])
 {         
 	static ARGPSTRUCT FCEUArgs[]={
-		{"-pal",         &pal_setting_specified,  &PAL,                  0},
+	    {"-rom",         0,                       &RomFile,               0x4001},
+	    {"-fullscreen",  0,                       &RunInFullscreen,       0},
+		{"-pal",         &pal_setting_specified,  &PAL,                   0},
 	    {"-dendy",       &dendy_setting_specified,&dendy,                 0},
         {"-noicon",      0,                       &status_icon,           0},
         {"-gg",          0,                       &genie,                 0},

--- a/src/drivers/win/args.h
+++ b/src/drivers/win/args.h
@@ -1,3 +1,5 @@
+extern char* RomFile;		//Contains the filename of the rom file in the command line arguments
+extern int RunInFullscreen;
 extern char* MovieToLoad;	//Contains the filename of the savestate specified in the command line arguments
 extern char* StateToLoad;	//Contains the filename of the movie file specified in the command line arguments
 extern char* ConfigToLoad;	//Contains the filename of the config file specified in the command line arguments

--- a/src/drivers/win/main.cpp
+++ b/src/drivers/win/main.cpp
@@ -856,15 +856,20 @@ int main(int argc,char *argv[])
 
 	InitSpeedThrottle();
 
-	if (t)
+	if (RomFile)
 	{
-		ALoad(t);
+		ALoad(RomFile);
 	} else
 	{
 		if (AutoResumePlay && romNameWhenClosingEmulator && romNameWhenClosingEmulator[0])
 			ALoad(romNameWhenClosingEmulator, 0, true);
 		if (eoptions & EO_FOAFTERSTART)
 			LoadNewGamey(hAppWnd, 0);
+	}
+	
+	if (RunInFullscreen) {
+		extern void ToggleFullscreen();
+		ToggleFullscreen();
 	}
 
 	if (PAL && pal_setting_specified && !dendy_setting_specified)
@@ -906,6 +911,8 @@ int main(int argc,char *argv[])
 		FCEU_LoadLuaCode(LuaToLoad);
 		free(LuaToLoad);
 		LuaToLoad = NULL;
+		extern HWND LuaConsoleHWnd;
+		ShowWindow(LuaConsoleHWnd, SW_MINIMIZE);
 	}
 
 	//Initiates AVI capture mode, will set up proper settings, and close FCUEX once capturing is finished


### PR DESCRIPTION
Hi, this adds the `-fullscreen 1` option for fullscreen mode, hides the lua window when running command line, and uses the `-rom` option to specify the rom file.
Launch example:
`fceux.exe -rom "1.nes" -lua "Rewinder.lua" -fullscreen 1`
This one will allow to launch FCEUX from other shells and play without a mouse.
The code may be used partially or completely.
Thanks.